### PR TITLE
fix: revert md:max-w-5xl back to md:max-w-[64rem] to preserve design intent

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -70,7 +70,7 @@ export default function IndexPage() {
             Browse our comprehensive selection of heavy construction equipment.
           </p>
         </div>
-        <div className="mx-auto grid justify-center gap-4 sm:grid-cols-2 md:max-w-5xl md:grid-cols-3">
+        <div className="mx-auto grid justify-center gap-4 sm:grid-cols-2 md:max-w-[64rem] md:grid-cols-3">
           <div className="relative overflow-hidden rounded-lg border bg-background p-2">
             <div className="flex h-[180px] flex-col justify-between rounded-md p-6">
               <Image


### PR DESCRIPTION
## Summary
Reverted an incorrect functional change where ESLint auto-fix changed `md:max-w-[64rem]` to `md:max-w-5xl`.

## Problem
The ESLint auto-fix incorrectly applied a `tailwindcss/no-unnecessary-arbitrary-value` suggestion that caused a **functional change**:

- `md:max-w-[64rem]` = **1024px** (64 × 16px) - Original design intent
- `md:max-w-5xl` = **1152px** (72 × 16px) - Incorrect auto-fix

This changed the layout width by 128px, affecting the design.

## Solution
- ✅ Reverted to `md:max-w-[64rem]` to preserve the original 1024px width
- ✅ Maintained all other valid classnames order improvements
- ✅ The arbitrary value represents a specific design decision and should be kept

## Type of Change
- [x] Bug fix (reverting unintended functional change)
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Layout width preserved at 1024px as intended
- [x] All other linting improvements maintained
- [x] No visual regression

The linting warning for this arbitrary value should be ignored as it represents a deliberate design choice.