### PR TITLE
fix: replace img with Next.js Image component (corrected implementation)

### DIFF
--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -26,6 +26,7 @@ import {
   X,
   type Icon as LucideIcon,
 } from "lucide-react"
+import NextImage from "next/image"
 
 export type Icon = LucideIcon
 
@@ -70,10 +71,11 @@ export const Icons = {
     </svg>
   ),
   linkedin: ({ ...props }: LucideProps) => (
-    <img
+    <NextImage
       src="/images/linkedin-icon.png"
       alt="LinkedIn"
-      className="h-5 w-5"
+      width={20}
+      height={20}
       {...props}
     />
   ),


### PR DESCRIPTION
## Summary
Replaced `<img>` element with Next.js `<Image />` component for the LinkedIn icon, **correcting the dimension conflict** identified in PR #131.

## Problem Addressed
PR #131 had a dimension conflict where:
- Hardcoded dimensions: `width={20} height={20}` (20px)
- Tailwind classes: `h-5 w-5` (1.25rem = 20px at default scale)

This created inconsistency between intrinsic size and CSS-forced dimensions.

## Solution
- ✅ Replaced `<img>` with Next.js `<Image />` component
- ✅ **Removed conflicting Tailwind size classes** (`h-5 w-5`)
- ✅ Uses intrinsic dimensions (`width={20} height={20}`) for consistent sizing
- ✅ Imported Next.js Image as `NextImage` to avoid conflict with lucide-react `Image`
- ✅ Resolved `@next/next/no-img-element` ESLint warning

## Performance Benefits
- **Automatic image optimization**: Next.js optimizes images automatically
- **Lazy loading**: Images load only when needed
- **Consistent sizing**: No CSS/intrinsic dimension conflicts
- **Better accessibility**: Proper alt text handling

## Testing
- [x] ESLint `no-img-element` warning resolved
- [x] No dimension conflicts between CSS and intrinsic size
- [x] Component functionality unchanged
- [x] Visual appearance preserved (20px × 20px)
- [x] No TypeScript errors

## Type of Change
- [x] Bug fix (resolves ESLint warning + dimension conflict)
- [x] Performance improvement
- [ ] New feature
- [ ] Breaking change

**Supersedes PR #131** - This corrected implementation resolves the dimension conflict issue identified by Copilot.