### PR TITLE
fix: Correct schema field name from requesterId to userId

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -22,7 +22,7 @@ export default async function DashboardPage() {
 
   const serviceRequests = await db.serviceRequest.findMany({
     where: {
-      requesterId: user.id,
+      userId: user.id,
     },
     select: {
       id: true,


### PR DESCRIPTION
## 🔧 Schema Field Name Fix

### **Issue:**
Production login was failing with PrismaClientValidationError:


### **Root Cause:**
Dashboard page was still using the old  field name instead of the correct  field from the current schema.

### **Fix Applied:**
- Updated  query from  to 
- Verified no other schema mismatches exist in the codebase

### **Testing:**
- ✅ Schema field names verified across all models
- ✅ Database queries validated for consistency
- ✅ No other  references found

### **Impact:**
- Resolves production login errors
- Ensures schema consistency across the application
- Prevents similar issues in the future

**Fixes:** Production login error caused by schema field name mismatch