### PR TITLE
fix: Remove unused routeContextSchema variables in API routes

### DIFF
--- a/app/api/posts/[postId]/route.ts
+++ b/app/api/posts/[postId]/route.ts
@@ -1,15 +1,9 @@
 import { getServerSession } from "next-auth"
-import * as z from "zod"
+import { z } from "zod"
 
 import { authOptions } from "@/lib/auth"
 import { db } from "@/lib/db"
 import { postPatchSchema } from "@/lib/validations/post"
-
-const routeContextSchema = z.object({
-  params: z.object({
-    postId: z.string(),
-  }),
-})
 
 export async function DELETE(
   req: Request,

--- a/app/api/service-requests/[requestId]/route.ts
+++ b/app/api/service-requests/[requestId]/route.ts
@@ -1,16 +1,10 @@
 import { getServerSession } from "next-auth"
-import * as z from "zod"
+import { z } from "zod"
 
 import { authOptions } from "@/lib/auth"
 import { db } from "@/lib/db"
 import { serviceRequestUpdateSchema } from "@/lib/validations/service-request"
 // Removed unused permission imports
-
-const routeContextSchema = z.object({
-  params: z.object({
-    requestId: z.string(),
-  }),
-})
 
 async function verifyCurrentUserHasAccessToRequest(requestId: string) {
   const session = await getServerSession(authOptions)

--- a/app/api/users/[userId]/operator-application/route.ts
+++ b/app/api/users/[userId]/operator-application/route.ts
@@ -5,12 +5,6 @@ import { authOptions } from "@/lib/auth"
 import { db } from "@/lib/db"
 import { operatorApplicationSchema } from "@/lib/validations/user"
 
-const routeContextSchema = z.object({
-  params: z.object({
-    userId: z.string(),
-  }),
-})
-
 export async function POST(
   req: Request,
   context: { params: Promise<{ userId: string }> }

--- a/app/api/users/[userId]/route.ts
+++ b/app/api/users/[userId]/route.ts
@@ -5,12 +5,6 @@ import { authOptions } from "@/lib/auth"
 import { db } from "@/lib/db"
 import { userNameSchema } from "@/lib/validations/user"
 
-const routeContextSchema = z.object({
-  params: z.object({
-    userId: z.string(),
-  }),
-})
-
 export async function PATCH(
   req: Request,
   context: { params: Promise<{ userId: string }> }


### PR DESCRIPTION
ESLint fix: Remove unused routeContextSchema variables that were causing CI failures after Next.js 15 upgrade.

Files updated:
- app/api/posts/[postId]/route.ts
- app/api/service-requests/[requestId]/route.ts  
- app/api/users/[userId]/route.ts
- app/api/users/[userId]/operator-application/route.ts

These schema definitions became unused after updating API routes for Next.js 15 async params pattern.

Changes:
- Removed unused routeContextSchema const declarations
- Kept zod imports for error handling (z.ZodError)
- Updated import style for consistency

Result: All ESLint warnings resolved, no functional changes.